### PR TITLE
Repara contexto de audio y añade tareas de mejora

### DIFF
--- a/TAREAS.md
+++ b/TAREAS.md
@@ -1,0 +1,7 @@
+# Tareas para VisualizadorXML
+
+- [ ] Probar la reproducción MIDI en distintos navegadores para validar el arreglo del `AudioContext`.
+- [ ] Añadir controles de volumen y selección de instrumento para cada pista.
+- [ ] Implementar pruebas automáticas que verifiquen la generación de MIDI y la animación del `playhead`.
+- [ ] Documentar en el README el flujo de carga y reproducción, incluyendo resolución de errores comunes.
+- [ ] Optimizar la precarga de soundfonts para reducir latencia al iniciar la reproducción.

--- a/app.js
+++ b/app.js
@@ -178,7 +178,8 @@ import { Midi } from "https://cdn.jsdelivr.net/npm/@tonejs/midi@2.0.28/+esm";
       }
       const tasks = [];
       needed.forEach(p => {
-        if (!instruments[p]) {
+        const inst = instruments[p];
+        if (!inst || inst.context !== ctx) {
           const name = programToName(p);
           const fonts = ['MusyngKite', 'FluidR3_GM'];
           const load = (i) => window.Soundfont.instrument(ctx, name, { soundfont: fonts[i] })
@@ -218,7 +219,11 @@ import { Midi } from "https://cdn.jsdelivr.net/npm/@tonejs/midi@2.0.28/+esm";
 
   function stopMidi(){
     if (rafId) cancelAnimationFrame(rafId);
-    if (ac){ try{ ac.close(); }catch(_){} ac = null; }
+    if (ac){
+      try{ ac.close(); }catch(_){}
+      ac = null;
+      for (const k in instruments) delete instruments[k];
+    }
     isPlaying = false; startAt = 0; timeInfo.textContent = '0.000 s';
     playBtn.textContent = '▶︎ Reproducir MIDI';
     clearHighlights();
@@ -366,6 +371,7 @@ import { Midi } from "https://cdn.jsdelivr.net/npm/@tonejs/midi@2.0.28/+esm";
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
     try { ac = new AudioCtx(); } catch(e){ alert('AudioContext no soportado.'); return; }
     if (ac.state === 'suspended') { try { await ac.resume(); } catch(_){} }
+    if (ac.state !== 'running') { alert('No se pudo iniciar el AudioContext.'); return; }
     try {
       await ensureInstruments(ac);
       startAt = ac.currentTime - (tStart || 0);


### PR DESCRIPTION
## Summary
- Recarga instrumentos de soundfont cuando el AudioContext cambia y limpia el registro al detener la reproducción.
- Verifica que el AudioContext se inicie correctamente antes de programar el MIDI para evitar silencios y animación detenida.
- Añade archivo de tareas para planificar mejoras futuras del visualizador.

## Testing
- `npm test` *(falla: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf77d2cc833392c5afbc1b011ea0