### PR TITLE
Fix audio playback scheduling

### DIFF
--- a/app.js
+++ b/app.js
@@ -243,7 +243,7 @@ import { computeNoteLeftPx, buildTempoMap, audioTimeToMs } from './player-utils.
         const vel = Math.max(0, Math.min(1, (n.velocity || 0.8) * vol));
         events.push({ time: tRel, midi: n.midi, gain: vel, duration: dur });
       });
-      if (events.length) inst.schedule(start, events);
+      if (events.length) inst.schedule(ctx.currentTime, events);
     });
   }
 


### PR DESCRIPTION
## Summary
- Ensure MIDI events are scheduled relative to the AudioContext's current time so notes aren't queued in the past

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7269858833381ca34c22365e424