### PR TITLE
Replace soundfont playback with basic oscillator

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico" />
   <!-- Verovio (WASM global) -->
   <script src="https://www.verovio.org/javascript/latest/verovio-toolkit-wasm.js" defer></script>
-  <!-- soundfont-player (v0.12.0). Si el CDN falla, el runtime intentará otros mirrors -->
-  <script src="https://cdn.jsdelivr.net/npm/soundfont-player@0.12.0/dist/soundfont-player.min.js" defer></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -50,10 +48,10 @@
     <div id="score"></div>
   </div>
 
-  <footer>
-    <div>Verovio + MIDI (SoundFont) — tira horizontal con playhead y autoscroll.</div>
-    <div id="vrvVersion" class="pill">Cargando Verovio…</div>
-  </footer>
+    <footer>
+      <div>Verovio + MIDI — tira horizontal con playhead y autoscroll.</div>
+      <div id="vrvVersion" class="pill">Cargando Verovio…</div>
+    </footer>
 </div>
 
 <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- remove external SoundFont dependency and strip instrument controls
- use Web Audio oscillators to schedule and play MIDI notes
- update UI footer to reflect simplified playback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6cbde2b008333864c6145c0151a64